### PR TITLE
LTI-47: Verify authorisation on actions performed on rooms and recordings

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -56,7 +56,7 @@ class RoomsController < ApplicationController
   def update
     respond_to do |format|
       if @room.update(room_params)
-        format.html { redirect_to @room, notice: t('default.room.updated') }
+        format.html { redirect_to room_path(@room, launch_nonce: params[:launch_nonce]), notice: t('default.room.updated') }
         format.json { render :show, status: :ok, location: @room }
       else
         format.html { render :edit }

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: room, local: true, class: "form fill") do |form| %>
+<%= form_with(model: room, local: true, class: "form fill", :url => room_path(@room, :launch_nonce => @launch_nonce) ) do |form| %>
   <% if room.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(room.errors.count, "error") %> prohibited this room from being saved:</h2>


### PR DESCRIPTION
Passes in the launch_nonce to update and show requests so that it will not result in a 401 error when trying to edit rooms.