### PR TITLE
LTI-64: configured localization for all elements

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,9 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body data-controller="<%= params[:controller] %>" data-action="<%= params[:action] %>" >
+  <body lang="<%= I18n.locale %>" 
+        data-controller="<%= params[:controller] %>" 
+        data-action="<%= params[:action] %>" >
     <%= yield %>
   </body>
 </html>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -27,17 +27,17 @@
   <% end %>
 
   <div class="field form-group input-group col-6">
-    <%= form.label :name %>&nbsp;<span class="text-muted small">*Required</span><br>
+    <%= form.label t('default.room.name') %>&nbsp;<span class="text-muted small">*Required</span><br>
     <%= form.text_field :name, :required => true, size: "45", class: "form-control input col-6" %>
   </div>
 
   <div class="field form-group input-group col-8">
-    <%= form.label :description %>
+    <%= form.label t('default.room.description') %>
     <%= form.text_area :description, size: "45x4", class: 'form-control input col-8' %>
   </div>
 
   <div class="field form-group input-group col-8">
-    <%= form.label :welcome %>
+    <%= form.label t('default.room.welcome') %>
     <%= form.text_area :welcome, size: "45x4", class: 'form-control input col-8' %>
   </div>
 
@@ -63,7 +63,7 @@
   </div>
 
   <div class="actions">
-    <%= form.submit class: "btn btn-primary" %>
+    <%= form.submit t('default.room.update'), class: "btn btn-primary" %>
     <%= form.button t('default.room.cancel'), class: "btn btn-default", name: "cancel" %>
   </div>
 <% end %>

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -17,7 +17,7 @@
   <td class="text-left">
     <% if recording[:published] %>
       <% recording[:playbacks].each do |p| %>
-        <%= link_to p[:type].capitalize, p[:url], class: "btn btn-sm btn-primary", target: "_blank" %>
+        <%= link_to t("default.recording.formats.#{p[:type].downcase}"), p[:url], class: "btn btn-sm btn-primary", target: "_blank" %>
       <% end %>
     <% end %>
   </td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,10 @@ Bundler.require(*Rails.groups)
 
 module BbbAppRooms
   class Application < Rails::Application
+    # Configure I18n localization.
+    config.i18n.available_locales = [:en, :pt]
+    config.i18n.default_locale = :en
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,10 @@ en:
         protected:    "Protected"
       no_matched_recordings: "No recordings matching search criteria"
       no_recordings: "No recordings"
+      formats:
+        video:        "Video"
+        presentation: "Presentation"
+        statistics:   "Statistics"
 
   error:
     http:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,125 @@
+pt:
+  default:
+    app:
+      error:          "Erro"
+    admin:
+      back:           "Voltar"
+      handler:        "Handler"
+      newroom:        "Nova sala"
+      showall:        "Exibir todas"
+      showroom:
+        text:         "Exibir"
+      editroom:
+        text:         "Editar"
+      destroyroom:
+        text:         "Remover"
+        confirmation: "Tem certeza que deseja remover esta sala?"
+    bigbluebutton:
+      moderator:      "Moderador"
+      viewer:         "Participante"
+    room:
+      created:        "A sala foi criada com sucesso"
+      edit:           "Editar"
+      editing:        "Editando sala"
+      show:           "Exibir"
+      showing:        "Exibindo sala"
+      destroy:        "Remover"
+      destroyed:      "A sala foi removida com sucesso"
+      join:           "Entrar"
+      name:           "Nome"
+      description:    "Descrição"
+      welcome:        "Boas-vindas"
+      moderator:      "Chave de moderador"
+      viewer:         "Chave de participante"
+      recording:      "Gravação"
+      recordings:     "Gravações"
+      waitmoderator:  "Aguarde moderador"
+      allmoderators:  "Todos moderadores"
+      update:         "Atualizar"
+      updated:        "Atualizado"
+      cancel:         "Cancelar"
+      tooltip:
+        recording:    "A sessão poderá ser gravada"
+        waitmoderator: "Participantes não podem entrar até que um moderador entre"
+        allmoderators: "Todos usuários serão moderadores"
+      waitmodmsg:        "Por favor espere até que um moderador entre na sala. Você será redirecionado automaticamente."
+    meeting:
+      close:           "Fechar janela"
+      close_manually:  "Esta janela deve ser fechada manualmente"
+    recording:
+        action:
+            delete:       "Delete pt"
+            edit:         "Editar"
+            protect:      "protect pt"
+            publish:      "Publish"
+            unprotect:    "Unprotect"
+            unpublish:    "Unpublish"
+        search_placeholder: "Search by Name or Description..."
+        table:
+            actions:      "Actions pt"
+            formats:      "Formats"
+            name:         "NamePt"
+            description:  "DescriptionPt"
+            date:         "DatePt"
+            duration:     "DurationPt"
+        visibility:
+            public:       "Public"
+            protected:    "Protected"
+        no_matched_recordings: "No recordings matching search criteria"
+        no_recordings: "No recordings pt"
+        formats:
+          video:        "Video"
+          presentation: "Presentation"
+          statistics:   "Statistics"
+ 
+  error:
+    http:
+      _401:
+        code:       "Unauthorized"
+        message:    "Acesso não autorizado"
+        suggestion: "Tente iniciar a sala novamente no seu LMS ou tente atualizar esta página no seu navegador."
+        status_code: "401"
+    bigbluebutton:
+      invalid_request:
+        code:       "BBBAPICallInvalid"
+        message:    "Chamada inválida para o BigBlueButton"
+        suggestion: "Certifique-se de que o servidor BigBlueButton sendo usado está disponível e acessível para o servidor onde a aplicação LTI está instalada."
+        status_code: "500"
+    generic:
+      404:
+        code: "NotFound"
+        message: "Não encontrado"
+        suggestion: "A página que você tentou acessar não foi encontrada."
+      500:
+        code: "ServerError"
+        message: "Erro no servidor"
+        suggestion: "Por favor tente novamente mais tarde ou entre em contato com um administrador."
+    room:
+      forbidden:
+        code:       "AccessForbidden"
+        message:    "A sessão expirou"
+        suggestion: "Se você está utilizando esta sala via LTI, tente iniciar a sala novamente no seu LMS ou tente atualizar esta página no seu navegador."
+        status_code: "403"
+      not_found:
+        code:       "NotFound"
+        message:    "A sala não foi encontrada"
+        suggestion: "A sala pode ter sido removida por um administrador. Contate o suporte técnico."
+        status_code: "404"
+      invalid_secret:
+        code:       "InvalidSecret"
+        message:    "O token não pode ser validado"
+        suggestion: "O problema pode ser causado pela utilização de uma chave inválida na validação da requisição feita pelo provedor LTI."
+        status_code: "403"
+    scheduled_meeting:
+      not_found:
+        code:       "NotFound"
+        message:    "O agendamento não foi encontrado"
+        suggestion: "Ele pode ter sido removido pelo criador da sessão."
+        status_code: "404"
+  views:
+    pagination:
+      first: "&laquo;"
+      last: "&raquo;"
+      previous: "&lsaquo;"
+      next: "&rsaquo;"
+      truncate: "&hellip;"

--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -85,6 +85,10 @@ module BbbApi
 
   # Helper for converting BigBlueButton dates into the desired format.
   def recording_date(date)
+    # note: if we really wanted ordinalization, then we can add an if statement to ordinalize if locale is en.
+    # .ordinalize does not work with other locales
+    return date.strftime("%B #{date.day}, %Y.") unless I18n.locale.eql?(:en)
+
     date.strftime("%B #{date.day.ordinalize}, %Y.")
   end
 

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -17,7 +17,7 @@
 #  with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 module BbbAppRooms
   class User
-    attr_accessor :uid, :full_name, :first_name, :last_name, :email, :roles
+    attr_accessor :uid, :full_name, :first_name, :last_name, :email, :roles, :locale
 
     def initialize(params)
       params.each do |key, value|


### PR DESCRIPTION
- Removed hard-coded text to be pulled from /config/locales
- We will try to get the locale from the LMS launch params. If the LMS doesn't provide that parameter we will get it from the user's browser. If the language isn't supported it will default to English. 
- mconf had a pt.yml locale file that I included. Not everything is translated to Portuguese in that file (because some fields differed between our en.yml and mconf's) but I just did it for testing purposes. I guess we would use transifex to generate other locales. 