### PR TITLE
LTI-83: Restrict formats to certain roles

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -159,7 +159,7 @@ class RoomsController < ApplicationController
     redirect_to(room_path(params[:id], launch_nonce: params[:launch_nonce]))
   end
 
-  helper_method :recordings, :recording_date, :recording_length, :bigbluebutton_moderator_roles, :mod_in_room?
+  helper_method :recordings, :recording_date, :recording_length, :bigbluebutton_moderator_roles, :mod_in_room?, :bigbluebutton_recording_public_formats
 
   private
 

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -17,7 +17,10 @@
   <td class="text-left" style='white-space: nowrap'>
     <% if recording[:published] %>
       <% recording[:playbacks].each do |p| %>
-        <%= link_to t("default.recording.formats.#{p[:type].downcase}"), p[:url], class: "btn btn-sm btn-primary", target: "_blank" %>
+        <% # Don't show playback if user isn't moderator and the type isn't set as public %>
+        <% unless !(@user.admin? || @user.moderator?(bigbluebutton_moderator_roles)) && !bigbluebutton_recording_public_formats.include?(p[:type]) %>
+          <%= link_to t("default.recording.formats.#{p[:type].downcase}"), p[:url], class: "btn btn-sm btn-primary", target: "_blank" %>
+        <% end %>
       <% end %>
     <% end %>
   </td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,7 @@ module BbbAppRooms
     config.bigbluebutton_endpoint = ENV['BIGBLUEBUTTON_ENDPOINT'] || 'http://test-install.blindsidenetworks.com/bigbluebutton/api'
     config.bigbluebutton_secret = ENV['BIGBLUEBUTTON_SECRET'] || '8cd8ef52e8e101574e400365b55e11a6'
     config.bigbluebutton_moderator_roles = ENV['BIGBLUEBUTTON_MODERATOR_ROLES'] || 'Instructor,Faculty,Teacher,Mentor,Administrator,Admin'
+    config.bigbluebutton_recording_public_formats = ENV['BIGBLUEBUTTON_RECORDING_PUBLIC_FORMATS'] || 'presentation'
 
     config.omniauth_path_prefix = "#{ENV['RELATIVE_URL_ROOT'] ? '/' + ENV['RELATIVE_URL_ROOT'] : ''}/rooms/auth"
     config.omniauth_site = ENV['OMNIAUTH_BBBLTIBROKER_SITE'] || 'http://localhost:3000'

--- a/dotenv
+++ b/dotenv
@@ -26,6 +26,7 @@ RELATIVE_URL_ROOT=apps
 # BIGBLUEBUTTON_ENDPOINT=http://test-install.blindsidenetworks.com/bigbluebutton/
 # BIGBLUEBUTTON_SECRET=8cd8ef52e8e101574e400365b55e11a6
 # BIGBLUEBUTTON_MODERATOR_ROLES=Instructor,Faculty,Teacher,Mentor,Administrator,Admin
+# BIGBLUEBUTTON_RECORDING_PUBLIC_FORMATS=presentation,video
 
 ## BigBlueButton LTI Broker configuration
 # In the broker run

--- a/dotenv
+++ b/dotenv
@@ -26,7 +26,7 @@ RELATIVE_URL_ROOT=apps
 # BIGBLUEBUTTON_ENDPOINT=http://test-install.blindsidenetworks.com/bigbluebutton/
 # BIGBLUEBUTTON_SECRET=8cd8ef52e8e101574e400365b55e11a6
 # BIGBLUEBUTTON_MODERATOR_ROLES=Instructor,Faculty,Teacher,Mentor,Administrator,Admin
-# BIGBLUEBUTTON_RECORDING_PUBLIC_FORMATS=presentation,video
+# BIGBLUEBUTTON_RECORDING_PUBLIC_FORMATS=presentation,capture
 
 ## BigBlueButton LTI Broker configuration
 # In the broker run

--- a/lib/bbb_api.rb
+++ b/lib/bbb_api.rb
@@ -28,6 +28,10 @@ module BbbApi
     Rails.configuration.bigbluebutton_moderator_roles.split(',')
   end
 
+  def bigbluebutton_recording_public_formats
+    Rails.configuration.bigbluebutton_recording_public_formats.split(',')
+  end
+
   def wait_for_mod?
     return unless @room && @user
 


### PR DESCRIPTION
Public formats can be specified in .env and everything else will only be visible to moderators.
All moderators feature will not override the list defined by BIGBLUEBUTTON_MODERATOR_ROLES.
By default, if this variable is not set up, only presentation will be public.