### PR TITLE
LTI-93: Fixed meeting info showing after refresh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'action-cable-testing'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'dotenv-rails'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    action-cable-testing (0.6.1)
+      actioncable (>= 5.0)
     actioncable (6.0.3.2)
       actionpack (= 6.0.3.2)
       nio4r (~> 2.0)
@@ -369,6 +371,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action-cable-testing
   activerecord-session_store
   bigbluebutton-api-ruby
   bootsnap (>= 1.1.0)

--- a/app/assets/javascripts/meetingInfo.js
+++ b/app/assets/javascripts/meetingInfo.js
@@ -11,9 +11,9 @@ $(document).on('turbolinks:load', function(){
       if (data.meeting_in_progress == true){
         startTime = data.elapsed_time
         in_progress = true;
-        show_end_meeting_btn();
-        display_participant_count(data.participant_count);
         start_elapsed_time();
+        display_participant_count(data.participant_count);
+        show_elems(); 
       }
       if (data.action == "end"){
         in_progress = false;
@@ -26,14 +26,14 @@ $(document).on('turbolinks:load', function(){
 var startTime = 0;
 var in_progress = false;
 
-var show_end_meeting_btn = function(){
+var show_elems = function(){
   $('#end-meeting-btn').show();
+  $('#meeting-info-msg').show();
 }
 
 var hide_elements = function(){
   $('#end-meeting-btn').hide();
   $('#meeting-info-msg').hide();
-  $('#elapsed-time-msg').hide();
 }
 
 var display_participant_count = function(participantCount){
@@ -42,8 +42,8 @@ var display_participant_count = function(participantCount){
   } else {
     var pplprson = "people";
   }
-  document.getElementById('meeting-info-msg').innerHTML = participantCount + " " + pplprson + " present. ";
-  $('#meeting-info-msg').show();
+  document.getElementById('num-ppl-in-meeting-elem').innerHTML = participantCount;
+  document.getElementById('ppl-or-person-elem').innerHTML = pplprson;
 }
 
 var start_elapsed_time = function(){
@@ -57,14 +57,8 @@ var start_elapsed_time = function(){
   secs = addZeroMaybe(secs);
   hrs = addZeroMaybe(hrs);
 
-  document.getElementById('elapsed-time-msg').innerHTML =  " The session has been running for " + hrs + ":" + mins + ":" + secs + " seconds.";
+  document.getElementById('elapsed-time-elem').innerHTML =  hrs + ":" + mins + ":" + secs;
 
-  $('#elapsed-time-msg').show();
-
-  if (!in_progress) {
-    $('#elapsed-time-msg').hide();
-    return; 
-  }
   setTimeout(start_elapsed_time, 500);
 }
 

--- a/app/channels/meeting_info_channel.rb
+++ b/app/channels/meeting_info_channel.rb
@@ -20,7 +20,7 @@ class MeetingInfoChannel < ApplicationCable::Channel
   def subscribed
     @room = Room.find(params[:room_id])
     stream_for(@room)
-    NotifyMeetingWatcherJob.perform_now(@room, {})
+    NotifyMeetingWatcherJob.set(wait: 1.second).perform_later(@room, {})
   end
 
   def unsubscribed

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -172,7 +172,7 @@ class RoomsController < ApplicationController
     redirect_to(room_path(params[:id], launch_nonce: params[:launch_nonce]))
   end
 
-  helper_method :recordings, :recording_date, :recording_length, :meeting_running?, :bigbluebutton_moderator_roles, :bigbluebutton_recording_public_formats
+  helper_method :recordings, :recording_date, :recording_length, :meeting_running?, :bigbluebutton_moderator_roles, :bigbluebutton_recording_public_formats, :meeting_info
 
   private
 

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -19,4 +19,26 @@ module RoomsHelper
   def autoclose_url
     'javascript:window.close();'
   end
+
+  def elapsed_time(start_time)
+    return 0 if start_time.nil?
+
+    time = DateTime.now - start_time
+
+    hrs = (time * 24).floor
+    time -= hrs / 24.to_f
+
+    mins = (time * 24 * 60).floor
+    time -= mins / 1440.to_f
+
+    secs = (time * 24 * 60 * 60).floor
+
+    "#{add_zero_maybe(hrs)}:#{add_zero_maybe(mins)}:#{add_zero_maybe(secs)}"
+  end
+
+  def add_zero_maybe(num)
+    num = '0' + num.to_s if num < 10
+
+    num
+  end
 end

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -20,10 +20,10 @@ module RoomsHelper
     'javascript:window.close();'
   end
 
-  def elapsed_time(start_time)
+  def elapsed_time(start_time, curr_time)
     return 0 if start_time.nil?
 
-    time = DateTime.now - start_time
+    time = curr_time - start_time
 
     hrs = (time * 24).floor
     time -= hrs / 24.to_f

--- a/app/jobs/notify_meeting_watcher_job.rb
+++ b/app/jobs/notify_meeting_watcher_job.rb
@@ -36,7 +36,7 @@ class NotifyMeetingWatcherJob < ApplicationJob
 
   def job_data(data)
     info = meeting_info
-    data[:meeting_in_progress] = (info[:returncode] == 'SUCCESS' || info[:returncode] == true)
+    data[:meeting_in_progress] = (info[:returncode] == 'SUCCESS' || info[:running] == true)
     # Data for meeting not in progress.
     (data[:action] = 'end') && (return data) unless data[:meeting_in_progress]
 

--- a/app/jobs/notify_meeting_watcher_job.rb
+++ b/app/jobs/notify_meeting_watcher_job.rb
@@ -36,13 +36,11 @@ class NotifyMeetingWatcherJob < ApplicationJob
 
   def job_data(data)
     info = meeting_info
-    data[:action] = 'end'
-    data[:meeting_in_progress] = (info[:returncode] == 'SUCCESS')
+    data[:meeting_in_progress] = (info[:returncode] == 'SUCCESS' || info[:returncode] == true)
     # Data for meeting not in progress.
-    return data unless data[:meeting_in_progress]
+    (data[:action] = 'end') && (return data) unless data[:meeting_in_progress]
 
     # Data for meeting in progress.
-    data.delete[:action]
     data[:elapsed_time] = info[:startTime]
     data[:participant_count] = info[:participantCount]
     data

--- a/app/views/shared/_room.html.erb
+++ b/app/views/shared/_room.html.erb
@@ -46,26 +46,41 @@
   <!-- room -->
   <div class="row">
     <div class="col-12">
-    <h1><%= @room.name %></h1>
+      <h1><%= @room.name %></h1>
 
-    <h3><%= @room.description %></h3>
+      <h3><%= @room.description %></h3>
+      <% visible = "display: none;" %>
+      <div class = "pull-left">
+        <%= button_tag t('default.room.join'), :type => 'button', :class => "btn btn-primary", id: 'join-room-btn', data: {url: meeting_join_path(@room, :launch_nonce => @launch_nonce), room: @room.id} %>
+        
+        <% if @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>
+          <% if meeting_running? %>
+            <% meeting_info_dict = meeting_info %>
+            <% elapsedTime = elapsed_time(meeting_info_dict[:startTime]) %>
+            <% pplPresent = meeting_info_dict[:participantCount] %>
+            <% if pplPresent == 1 %>
+              <% pplprson = "person" %>
+            <% else %>
+              <% pplprson = "people" %>
+            <% end %>
+            <% visible = nil %>
+          <% end %>  
+          <%= button_tag t('default.room.endmeeting'), :type => 'button', :class => "btn btn-danger", id: 'end-meeting-btn', style: visible, data: {url: meeting_end_path(@room, :launch_nonce => @launch_nonce), room: @room.id} %>
+        <% end %> 
+      </div>
 
-    <div class = "pull-left">
-      <%= button_tag t('default.room.join'), :type => 'button', :class => "btn btn-primary", id: 'join-room-btn', data: {url: meeting_join_path(@room, :launch_nonce => @launch_nonce), room: @room.id} %>
-
-      <% if @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>
-        <% if meeting_running? %>
-          <% NotifyMeetingWatcherJob.perform_now(@room, {}) %>
-        <% end %>
-        <%= button_tag t('default.room.endmeeting'), :type => 'button', :class => "btn btn-danger", id: 'end-meeting-btn', style: "display:none;", data: {url: meeting_end_path(@room, :launch_nonce => @launch_nonce), room: @room.id} %>
-      <% end %>
-    </div>
-
-    <%= content_tag(:p, '', :class => "pull-left" , :style => "display:none; margin-left: 5px; margin-top: 5px", :id => 'meeting-info-msg') %>
-    <%= content_tag(:p, '', :class => "pull-left", :style => "display:none; margin-left: 5px; margin-top: 5px", :id => 'elapsed-time-msg') %>
-
-    <%= content_tag(:p, t('default.room.waitmodmsg'), :style => "display:none;", id: 'wait-for-mod-msg') %>
-
+      <div class = "pull-left" style = "margin-left: 5px; margin-top: 5px"> 
+        <p id= "meeting-info-msg" style = "<%= visible %>" > 
+          <span id="num-ppl-in-meeting-elem"> <%= pplPresent %> </span>
+          <span id="ppl-or-person-elem"> <%= pplprson %> </span>
+          present. The session has been running for 
+          <span id="elapsed-time-elem"> <%= elapsedTime %> </span> 
+          seconds.
+        </p>
+      </div>
+   
+      <%= content_tag(:p, t('default.room.waitmodmsg'), :style => "display:none;", id: 'wait-for-mod-msg') %>
+  
     </div>
   </div>
 

--- a/app/views/shared/_room.html.erb
+++ b/app/views/shared/_room.html.erb
@@ -56,7 +56,7 @@
         <% if @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>
           <% if meeting_running? %>
             <% meeting_info_dict = meeting_info %>
-            <% elapsedTime = elapsed_time(meeting_info_dict[:startTime]) %>
+            <% elapsedTime = elapsed_time(meeting_info_dict[:startTime], DateTime.now) %>
             <% pplPresent = meeting_info_dict[:participantCount] %>
             <% if pplPresent == 1 %>
               <% pplprson = "person" %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,7 +2,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: <%= ENV['CABLE_ADAPTER'] || 'async' %>

--- a/spec/channels/meeting_info_channel_spec.rb
+++ b/spec/channels/meeting_info_channel_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe(MeetingInfoChannel, type: :channel) do
+  it 'subscribes to a stream when room id is provided' do
+    @room = create(:room)
+    subscribe(room_id: @room.id)
+
+    expect(subscription).to(be_confirmed)
+  end
+end

--- a/spec/controllers/rooms_spec.rb
+++ b/spec/controllers/rooms_spec.rb
@@ -84,4 +84,11 @@ describe RoomsController, type: :controller do
       }
     end
   end
+
+  describe '#meeting_end' do
+    it 'should end the meeting' do
+      post :meeting_end, params: { id: @room.id }
+      expect(response). to(have_http_status(:success))
+    end
+  end
 end

--- a/spec/helpers/rooms_helper_spec.rb
+++ b/spec/helpers/rooms_helper_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe(RoomsHelper, type: :helper) do
+  describe '#elapsed_time' do
+    it 'returns the elapsed time' do
+      time = DateTime.new(2001, 2, 3, 4, 5, 6)
+      expect(helper.elapsed_time(time, time)).to(eql('00:00:00'))
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 
 require 'rspec/rails'
 require 'support/factory_bot.rb'
+require 'action_cable/testing/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Meeting info will be rendered in the HTML so that there is no delay in showing the elements after a refresh. 

To be merged after the LTI-66 fix and before LTI-95  (2/3)