### PR TITLE
LTI-102: Fix for edit recording name/description not working on Firefox

### DIFF
--- a/app/assets/javascripts/rename.js
+++ b/app/assets/javascripts/rename.js
@@ -40,8 +40,13 @@ $(document).on('turbolinks:load', function(){
           submit_rename_request(recording_text)
         };
 
-        $input.one('blur', save).focus();
-
+        $input.on('blur keyup', function(e) {
+          if (e.type === 'blur' || e.keyCode === 13)  { // keycode is depreciated by still recognized by browsers, it's alt (.key) doesnt work in firefox
+            save();
+            this.focus();
+          }
+        });
+       
         // Register the events for being able to exit the input box.
         register_window_event(recording_text, recording_text_id, '#edit-record', 'edit-recordid');
       }


### PR DESCRIPTION
Now, pressing enter will allow an admin to edit the name and description of recordings.

The issue is that it wasn't recognizing a 'blur' event. Adding 'keyup' and the check for an enter key event seems to fix it. 

Next step: figure out what's going on when you click outside the input field instead of pressing enter... (often results in an internal server error for the post request)