### PR TITLE
LTI-116: Improve performance on rooms

### DIFF
--- a/app/assets/javascripts/meetingInfo.js
+++ b/app/assets/javascripts/meetingInfo.js
@@ -10,6 +10,7 @@ $(document).on('turbolinks:load', function(){
           console.log("Connected to meeting info channel");
       },
       disconnected: function() {
+        console.log("Disconnected from meeting info channel");
       },
       received: function(data) {
         console.log("received data: " + JSON.stringify(data));

--- a/app/channels/wait_channel.rb
+++ b/app/channels/wait_channel.rb
@@ -19,6 +19,8 @@ class WaitChannel < ApplicationCable::Channel
   def subscribed
     @room = Room.find(params[:room_id])
     stream_for(@room)
+  rescue ActiveRecord::RecordNotFound
+    nil # To catch attempts to subscribe when wait for mod isn't required.
   end
 
   def unsubscribed

--- a/app/controllers/concerns/bbb_helper.rb
+++ b/app/controllers/concerns/bbb_helper.rb
@@ -144,7 +144,16 @@ module BbbHelper
   def wait_for_mod?
     return unless @room && @user
 
-    @room.wait_moderator && !@user.moderator?(bigbluebutton_moderator_roles)
+    cached_wait = Rails.cache.fetch("#{@room.handler}/#{__method__}")
+    return cached_wait unless cached_wait.nil?
+
+    wait = @room.wait_moderator && !@user.moderator?(bigbluebutton_moderator_roles)
+
+    Rails.cache.fetch("#{@room.handler}/#{__method__}", expires_in: 5.minutes) do
+      wait
+    end
+
+    wait
   end
 
   # Return the number of participants in a meeting for the current room.

--- a/app/controllers/concerns/bbb_helper.rb
+++ b/app/controllers/concerns/bbb_helper.rb
@@ -61,7 +61,13 @@ module BbbHelper
 
   # Perform ends meeting for the current @room.
   def end_meeting
-    bbb.end_meeting(@room.handler, @room.moderator)
+    response = { returncode: 'FAILED' }
+    begin
+      response = bbb.end_meeting(@room.handler, @room.moderator)
+    rescue BigBlueButton::BigBlueButtonException
+      # this can be thrown if all participants left (clicked 'x' before pressing the end button)
+    end
+    response
   end
 
   # Retrieves meeting info for the current Room.

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -103,18 +103,17 @@ class RoomsController < ApplicationController
   # POST /rooms/:id/meeting/join
   # POST /rooms/:id/meeting/join.json
   def meeting_join
-    # make user wait until moderator is in room
     wait = wait_for_mod? && !meeting_running?
-    broadcast_meeting(action: 'join', delay: true) unless wait
-
-    NotifyRoomWatcherJob.set(wait: 5.seconds).perform_later(@room, { action: 'started' }) unless wait
     @meeting = join_meeting_url
+
     if wait
       respond_to do |format|
         format.html
         format.json { render(json: { wait_for_mod: wait, meeting: @meeting }) }
       end
     else
+      broadcast_meeting(action: 'join', delay: true)
+      NotifyRoomWatcherJob.set(wait: 5.seconds).perform_later(@room, { action: 'started' }) if @room.wait_moderator
       redirect_to(@meeting)
     end
   end
@@ -123,6 +122,7 @@ class RoomsController < ApplicationController
   # GET /rooms/:id/meeting/end.json
   def meeting_end
     end_meeting
+    redirect_to(room_path(@room.id, launch_nonce: params['launch_nonce'])) # fallback if actioncable doesn't work
   end
 
   def broadcast_meeting(action: 'none', delay: false)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -31,7 +31,7 @@ class RoomsController < ApplicationController
   before_action :check_for_cancel, only: [:create, :update]
   before_action :allow_iframe_requests
   before_action :set_current_locale
-  after_action :broadcast_meeting, only: [:show, :launch, :meeting_end]
+  after_action :broadcast_meeting, only: [:meeting_end]
 
   # GET /rooms/1
   # GET /rooms/1.json

--- a/spec/controllers/rooms_spec.rb
+++ b/spec/controllers/rooms_spec.rb
@@ -88,7 +88,7 @@ describe RoomsController, type: :controller do
   describe '#meeting_end' do
     it 'should end the meeting' do
       post :meeting_end, params: { id: @room.id }
-      expect(response). to(have_http_status(:success))
+      expect(response). to(have_http_status(:found))
     end
   end
 end


### PR DESCRIPTION
- Reduces number of broadcasts, hence reducing number of API calls being made.
- Also fixes the 500 error that occurs if an instructor presses 'end meeting' after the meeting is already done.