### PR TITLE
LTI-241: Request name before joining meeting if not included in launch

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -129,6 +129,17 @@ class RoomsController < ApplicationController
   # POST /rooms/:id/meeting/join
   # POST /rooms/:id/meeting/join.json
   def meeting_join
+    @user.full_name ||= cookies[:full_name] # if full_name in cookies, use that.
+    @user.full_name ||= params[:full_name] # if it's coming form name_form, this param will be populated
+    cookies[:full_name] ||= @user.full_name # set cookie if null
+
+    # if name was not passed by the LMS, prompt for name before joining meeting
+    unless @user.full_name
+      respond_to do |format|
+        format.html { render(:name_form) }
+      end and return
+    end
+
     wait = wait_for_mod? && !meeting_running?
     @meeting = join_meeting_url
 

--- a/app/views/rooms/name_form.html.erb
+++ b/app/views/rooms/name_form.html.erb
@@ -1,0 +1,33 @@
+<%
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+%>
+
+<body>
+    <div class="container">
+
+        <%= form_with(local: false, url: meeting_join_path(@room, :launch_nonce => @launch_nonce), method: "post") do |form| %>
+        <div class="bg-gray-200 grid justify-items-center grid-cols-1 py-28 px-10 mt-40 ">
+            <div class="field form-group input-group rounded">
+            
+                <%= form.label t('default.meeting.user_full_name') , style: "display: inline" %>
+            
+                <%= form.text_field :full_name, :required => true,  class: "form-control rounded input mt-1 ml-2" %>
+            </div>
+            <p class="text-center p-2"><%= t('default.meeting.personal_info_message') %> </p>
+            <%= button_tag t('default.app.accept'),:type => 'submit', :class => "font-sans text-center text-white px-4 py-2 w-50 mb-0 border border-bbb-blue bg-bbb-blue rounded hover:bg-darker-bbb-blue", id: 'join-room-btn', formtarget: "_blank", data: {url: meeting_join_path(@room, :launch_nonce => @launch_nonce), room: @room.id} %>
+            </div>
+        <% end %>
+       
+    </div>
+</body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
   default:
     app:
       error:          "Error"
+      accept:         "Accept"
     admin:
       back:           "Back"
       handler:        "Handler"
@@ -128,6 +129,8 @@ en:
     meeting:
       close:          "Close tab/window"
       close_manually: "This tab/window must be closed manually"
+      user_full_name: "Full Name"
+      personal_info_message: "This Tool Consumer does not pass personal information to external applications. BigBlueButton require a way to identify users during the live session. By accepting this, you agree to pass your name to BigBlueButton for the purposes of identification during the meeting."
     recording:
       action:
         delete:       "Delete"


### PR DESCRIPTION
When the launch does not come with lis_person_fullname parameter, the page for joining shows a form where the user is asked to set the name and accept otherwise they are not let in.