### PR TITLE
LTI-259: include scope in omniauth authenticator

### DIFF
--- a/app/controllers/concerns/omniauth_helper.rb
+++ b/app/controllers/concerns/omniauth_helper.rb
@@ -29,6 +29,7 @@ module OmniauthHelper
       grant_type: 'client_credentials',
       client_id: Rails.configuration.omniauth_key,
       client_secret: Rails.configuration.omniauth_secret,
+      scope: 'api',
     }
     response = RestClient.post("#{lti_broker_url}/oauth/token", oauth_options)
     JSON.parse(response)['access_token']


### PR DESCRIPTION
The scope is required with doorkeeper 2.6.0+ since the default scope is no longer accepted