### PR TITLE
LTI-279: use params from broker for room handler if specified

### DIFF
--- a/app/controllers/concerns/bbb_helper.rb
+++ b/app/controllers/concerns/bbb_helper.rb
@@ -182,13 +182,13 @@ module BbbHelper
   # Return the number of participants in a meeting for the current room.
   def participant_count
     info = meeting_info
-    return info[:participantCount] if info[:returncode] == 'SUCCESS'
+    info[:participantCount] if info[:returncode] == 'SUCCESS'
   end
 
   # Return the meeting start time for the current room.
   def meeting_start_time
     info = meeting_info
-    return info[:startTime] if info[:returncode] == 'SUCCESS'
+    info[:startTime] if info[:returncode] == 'SUCCESS'
   end
 
   def bigbluebutton_moderator_roles

--- a/app/controllers/concerns/broker_helper.rb
+++ b/app/controllers/concerns/broker_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/.
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; either version 3.0 of the License, or (at your option) any later
+# version.
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+module BrokerHelper
+  extend ActiveSupport::Concern
+
+  include OmniauthHelper
+
+  # Fetch tenant settings from the broker
+  def tenant_settings(options = {})
+    tenant = options[:tenant] || @room&.tenant || ''
+    Rails.cache.fetch("rooms/tenant_settings/#{tenant}", expires_in: 1.hour) do
+      bbbltibroker_url = omniauth_bbbltibroker_url("/api/v1/tenants/#{tenant}")
+      get_response = RestClient.get(bbbltibroker_url, 'Authorization' => "Bearer #{omniauth_client_token(omniauth_bbbltibroker_url)}")
+
+      JSON.parse(get_response)
+    end
+  rescue StandardError => e
+    Rails.logger.error("Could not fetch tenant credentials from broker. Error message: #{e}")
+    nil
+  end
+
+  # Fetch the params to use when creating the room handler
+  def handler_params(tenant)
+    tenant_settings(tenant: tenant)&.[]('settings')&.[]('handler_params')&.split(',')
+  end
+end


### PR DESCRIPTION
**Description**
A custom 'handler_params' setting can be added to tenants in the broker via the new rake task. These params can be used in the rooms app to form the room handler. By default, if no params are specified in the broker, the app will use the 'resource_link_id' parameter to form the handler.

**How to Specify Params**
```
# The rake task first takes a tenant's uid. the second parameter must be 'handler_params', and the third parameter is a string with as many params as you like, separated by an escaped comma, as shown below:
rake db:tenants:settings:upsert[tenant_id,handler_params,"context_id\,resource_link_id"] 

# You can delete handler parameters by using the following task:
rake db:tenants:settings:delete_handler_params[tenant_uid,handler_params]
```

**Things to Note**
Ensure that you are using the correct version of the Broker that supports using handler params from the broker.
By changing the params used for the handler will change, you will lose previous instances of Rooms. They won't be deleted from the database, but rather if you launch a Room that had been previously set up, it will be launched as a new room. The major consequence of this is that any recordings in the previous room will be lost.

**How to test**
In the broker, specify the params you would like to use for your tenant's rooms, and then create various rooms within one course and across a couple of courses, ensuring that the rooms are unique (this can be done by simply changing the room name or description).