### PR TITLE
LTI-281: Only set legacy handler if new room enabled

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
       _410:
         code:       "Gone"
         message:    "Unreachable resource"
-        suggestion: "It seems that you are trying to access this resource using an LTI endpoint that is no longer supported. Try updating the endpoint o credentials for the external tool"
+        suggestion: "It seems that you are trying to access this resource using an LTI endpoint that is no longer supported. Try updating the endpoint or credentials for the external tool"
     bigbluebutton:
       invalidrequest:
         code:       "BBBAPICallInvalid"


### PR DESCRIPTION
If `handler_legacy_api_enabled=false` and `handler_legacy_new_room_enabled=true` , then reset the `handler_legacy=nil` so that the newly generated handler (handler) is used instead (just like non-legacy rooms). If the admin sets `handler_legacy_new_room_enabled=false`, then a nil room will be returned (ie. 401 error). Given  `handler_legacy_api_enabled=false`, this option would essentially allow anyone to use a legacy URL, even if it is not linked to an actual konekti room, and it would have the same effects as using the new URL format