### PR TITLE
LTI-257: Limit power of shared room admins to end meeting, edit recordings

### DIFF
--- a/app/views/shared/_room.html.erb
+++ b/app/views/shared/_room.html.erb
@@ -132,7 +132,7 @@
           <% end %> 
         </div>
         <div>
-          <% if @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>
+          <% if !@room.use_shared_code && (@user.admin? || @user.moderator?(bigbluebutton_moderator_roles)) %>
             <%= button_tag t('default.room.endmeeting'), 
                 type: 'button', 
                 class: "font-sans text-center text-red-600 border ml-2 border-red-600 px-4 py-2 w-50 mb-0 bg-white rounded hover:text-white hover:bg-red-600", 

--- a/app/views/shared/components/_recording_row.html.erb
+++ b/app/views/shared/components/_recording_row.html.erb
@@ -15,7 +15,7 @@
 <tr class="border-b text-left ">
   <td class="p-0">
     <div class="text-left font-sans px-5 py-3 ">
-      <% can_edit = @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>
+      <% can_edit = !@room.use_shared_code && (@user.admin? || @user.moderator?(bigbluebutton_moderator_roles)) %>
       <% if can_edit %>
         <% hover = 'bg-gray-100' %>
         <% focus = 'bg-white' %>
@@ -30,9 +30,11 @@
             <text id='recording-title-text' class="text-wrap input recording-text"><%= recording[:name] %></text>
           <% end %>
            <a>
+					 <% if can_edit %>
             <svg id="edit-record-description" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4  bg-white hover:text-blue-700 hover:bg-white text-gray-700" data-edit-recordid="<%= recording[:recordID] %>">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
             </svg>
+						<% end %>
           </a>  
 
       </div>
@@ -41,7 +43,7 @@
            data-launch-nonce="<%= @launch_nonce %>"
            data-can-edit="<%= can_edit %>">
         <text id='recording-description-text' class="text-wrap recording-text"><%= recording[:metadata][:description] %></text>
-        <% if @user.admin? || @user.moderator?(bigbluebutton_moderator_roles) %>  
+        <% if can_edit %>  
           <a>
             <svg id="edit-record-description" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4  bg-white hover:text-blue-700 hover:bg-white text-gray-700" data-edit-recordid="<%= recording[:recordID] %>">
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.832 19.82a4.5 4.5 0 01-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />


### PR DESCRIPTION
Hide the 'end meeting' button for admins using a shared room. Only the original owner has the power to end meetings. Also, only the original owner has the ability to edit the recordings. 