### PR TITLE
LTI-291: enable shared rooms from tenant settings

### DIFF
--- a/app/controllers/concerns/broker_helper.rb
+++ b/app/controllers/concerns/broker_helper.rb
@@ -36,4 +36,9 @@ module BrokerHelper
   def handler_params(tenant)
     tenant_settings(tenant: tenant)&.[]('settings')&.[]('handler_params')&.split(',')
   end
+
+  # See whether shared rooms have been enabled in tenant settings. They are disabled by default.
+  def shared_rooms_enabled(tenant)
+    tenant_settings(tenant: tenant)&.[]('settings')&.[]('enable_shared_rooms') == 'true' || false
+  end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -249,7 +249,7 @@ class RoomsController < ApplicationController
   end
 
   helper_method :recording_date, :recording_length, :meeting_running?, :bigbluebutton_moderator_roles,
-                :bigbluebutton_recording_public_formats, :meeting_info, :bigbluebutton_recording_enabled, :server_running?
+                :bigbluebutton_recording_public_formats, :meeting_info, :bigbluebutton_recording_enabled, :server_running?, :shared_rooms_enabled
 
   private
 

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -125,21 +125,23 @@
   <!-- Shared Room Stuff -->
   <%= form.hidden_field :code, id: 'room_code_value', value: @room.code %> 
 
-  <div class="field form-group input-group w-full pt-4">
-    <%= form.label t('default.room.code') %>
-    <%= form.text_field :shared_code, class: "form-control input mt-1 block disabled:border-slate-200 disabled:text-slate-500 disabled:shadow-none disabled:bg-slate-100", id: 'shared_code_field', disabled: true %>
-  </div>
+	<% if shared_rooms_enabled(@room.tenant) %>
+		<div class="field form-group input-group w-full pt-4">
+			<%= form.label t('default.room.code') %>
+			<%= form.text_field :shared_code, class: "form-control input mt-1 block disabled:border-slate-200 disabled:text-slate-500 disabled:shadow-none disabled:bg-slate-100", id: 'shared_code_field', disabled: true %>
+		</div>
 
-	<% unless flash[:alert] == nil %>
-		<div class="ml-3 text-sm font-medium text-red-500">
-      <%= flash.alert %>
-    </div>
+		<% unless flash[:alert] == nil %>
+			<div class="ml-3 text-sm font-medium text-red-500">
+				<%= flash.alert %>
+			</div>
+		<% end %>
+		<div class="field form-group input-group">
+			<%= form.check_box :use_shared_code, id: 'use_shared_code_checkbox' %>&nbsp;
+			<%= t('default.room.usesharedcode') %>&nbsp;
+			<br>
+		</div>
 	<% end %>
-  <div class="field form-group input-group">
-    <%= form.check_box :use_shared_code, id: 'use_shared_code_checkbox' %>&nbsp;
-    <%= t('default.room.usesharedcode') %>&nbsp;
-    <br>
-  </div>
 
 
   <div class="actions pt-6">


### PR DESCRIPTION
Shared rooms are now false by default. They can be enabled per tenant from the broker by adding the following setting:
`enable_shared_rooms=true`