### PR TITLE
LTI-289: Alter Shared Rooms UI to improve usability

### DIFF
--- a/app/javascript/packs/edit.js
+++ b/app/javascript/packs/edit.js
@@ -43,7 +43,7 @@ $(document).on('turbolinks:load', function(){
         }, 2000);
     })
 
-    $('#use_shared_code_checkbox').on('click', function() {
+    function handleUseSharedCodeCheckbox() {
         var textAreas = $('.check-disabled');
         var elements = $('.lock-visibility');
         var use_shared_code_checked = $('#use_shared_code_checkbox').prop("checked");
@@ -56,7 +56,11 @@ $(document).on('turbolinks:load', function(){
             textAreas.removeClass('disabled-textarea');
             elements.css('display', 'none');
         }
-    });
+    }
+
+    $('#use_shared_code_checkbox').on('click', handleUseSharedCodeCheckbox);
+
+    handleUseSharedCodeCheckbox();
 
     $('#allModerators_checkbox').on('click', function() {
         var all_mod_checked = $('#allModerators_checkbox').prop("checked");


### PR DESCRIPTION
Fixed the issue with the lock icons and input fields are no longer being disabled after a user decides to use the shared code, then clicks the update button and then clicks the edit room link. Now, a user can decide to use the shared code, click update, go back to editing a room, and the input fields, as well as the lock icons will be available.