### PR TITLE
LTI-326: implemented user_image feature

### DIFF
--- a/app/controllers/concerns/bbb_helper.rb
+++ b/app/controllers/concerns/bbb_helper.rb
@@ -56,6 +56,7 @@ module BbbHelper
     join_options = {}
     join_options[:createTime] = meeting_info[:createTime]
     join_options[:userID] = @user.uid
+    join_options[:avatarURL] = @user.user_image
     bbb.join_meeting_url(@chosen_room.handler, @user.username(t("default.bigbluebutton.#{role}")), @chosen_room.attributes[role], join_options)
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -443,6 +443,7 @@ class RoomsController < ApplicationController
       email: launch_params['lis_person_contact_email_primary'],
       roles: launch_params['roles'],
       locale: launch_params['launch_presentation_locale'],
+      user_image: launch_params['user_image'],
     }
   end
 

--- a/lib/bbb_app_rooms/user.rb
+++ b/lib/bbb_app_rooms/user.rb
@@ -18,7 +18,7 @@
 
 module BbbAppRooms
   class User
-    attr_accessor :uid, :full_name, :first_name, :last_name, :email, :roles, :locale
+    attr_accessor :uid, :full_name, :first_name, :last_name, :email, :roles, :locale, :user_image
 
     def initialize(params)
       params.each do |key, value|


### PR DESCRIPTION
In Canvas, users can now have their profile picture be transfered over into the big blue button meeting next to their name.