### PR TITLE
LTI-388, LTI-389, LTI-390: improvements and fixes to param forwarding

### DIFF
--- a/app/controllers/concerns/bbb_helper.rb
+++ b/app/controllers/concerns/bbb_helper.rb
@@ -288,11 +288,9 @@ module BbbHelper
   # - action: either 'join' or 'create'
   # - options: the hash of params sent as part of the request
   def add_ext_params(action, options)
-    ext_params = tenant_setting(@chosen_room.tenant, 'ext_params')
-
-    @chosen_room.settings['ext_params']&.[](action)&.each do |key, value|
+    @extra_params_to_bbb[action]&.each do |key, value|
       # the value in ext_params from the tenant settings is the name that should be passed to BBB
-      bbb_name = ext_params&.[](action)&.[](key)
+      bbb_name = @broker_ext_params&.[](action)&.[](key)
       options[bbb_name] = value if bbb_name
     end
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -540,7 +540,7 @@ class RoomsController < ApplicationController
     pass_on_join_params = lms_custom_params.select { |k, _| @broker_ext_params&.[]('join')&.key?(k) }
     pass_on_create_params = lms_custom_params.select { |k, _| @broker_ext_params&.[]('create')&.key?(k) }
 
-    @extra_params_to_bbb = { join: pass_on_join_params, create: pass_on_create_params }
+    @extra_params_to_bbb = { 'join' => pass_on_join_params, 'create' => pass_on_create_params }
 
     logger.debug("[Rooms Controller] The extra parameters to be passed to BBB are: #{@extra_params_to_bbb}")
   rescue StandardError => e

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -53,14 +53,6 @@ class Room < ApplicationRecord
     RECORDING_SETTINGS.include?(setting.to_sym)
   end
 
-  # Add key-value paris to the settings jsonb column
-  # new-settings is a hash
-  def add_settings(new_settings)
-    updated_settings = settings.deep_merge(new_settings)
-
-    update(settings: updated_settings)
-  end
-
   private
 
   def random_password(length, reference = '')

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,7 @@ module BbbAppRooms
     # Settings for external services.
     config.cache_enabled = ENV.fetch('CACHE_ENABLED', 'false').casecmp?('true')
     config.cache_expires_in_minutes = ENV.fetch('CACHE_EXPIRES_IN_MINUTES', '10').to_i
+    config.cache_expires_in_seconds = ENV.fetch('CACHE_EXPIRES_IN_SECONDS', '60').to_i
     config.external_multitenant_endpoint = ENV['EXTERNAL_MULTITENANT_ENDPOINT']
     config.external_multitenant_secret = ENV['EXTERNAL_MULTITENANT_SECRET']
     config.tenant_credentials = ENV['TENANT_CREDENTIALS'] || '{}'

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,6 @@ module BbbAppRooms
     # Settings for external services.
     config.cache_enabled = ENV.fetch('CACHE_ENABLED', 'false').casecmp?('true')
     config.cache_expires_in_minutes = ENV.fetch('CACHE_EXPIRES_IN_MINUTES', '10').to_i
-    config.cache_expires_in_seconds = ENV.fetch('CACHE_EXPIRES_IN_SECONDS', '60').to_i
     config.external_multitenant_endpoint = ENV['EXTERNAL_MULTITENANT_ENDPOINT']
     config.external_multitenant_secret = ENV['EXTERNAL_MULTITENANT_SECRET']
     config.tenant_credentials = ENV['TENANT_CREDENTIALS'] || '{}'

--- a/spec/concerns/bbb_helper_spec.rb
+++ b/spec/concerns/bbb_helper_spec.rb
@@ -28,6 +28,13 @@ describe BbbHelper do
 
   before do
     @room = @chosen_room = create(:room)
+    @extra_params_to_bbb = { join: { 'custom_one' => 'this is one' }, create: { 'custom_two' => 'this is two' } }
+    @broker_ext_params = {
+      'join' =>
+        { 'custom_one' => 'userdata-bbb_one' },
+      'create' =>
+        { 'custom_two' => 'meta_bbb_two' },
+    }
     allow_any_instance_of(BbbHelper).to(receive(:bbb).and_return(bbb_api))
     allow_any_instance_of(BrokerHelper).to(receive(:broker_tenant_info).and_return({
                                                                                      'handler_params' => 'context_id',
@@ -38,9 +45,9 @@ describe BbbHelper do
                                                                                      'bigbluebutton_moderator_roles' => 'administrator,teacher',
                                                                                      'ext_params' => {
                                                                                        'join' =>
-                                                                                         { 'custom_user_image' => 'ext_user_image' },
+                                                                                         { 'custom_one' => 'userdata-bbb_one' },
                                                                                        'create' =>
-                                                                                          { 'custom_context_id' => 'ext_course_id' },
+                                                                                         { 'custom_two' => 'meta_bbb_two' },
                                                                                      },
                                                                                    }))
   end

--- a/spec/controllers/rooms_spec.rb
+++ b/spec/controllers/rooms_spec.rb
@@ -9,6 +9,17 @@ describe RoomsController, type: :controller do
   before :each do
     allow_any_instance_of(RoomsController).to(receive(:authenticate_user!).and_return(:success))
     allow_any_instance_of(RoomsController).to(receive(:bbb).and_return(bbb_api))
+    allow_any_instance_of(RoomsController).to(receive(:launch_request_params)).and_return({
+                                                                                            'token' => '319bda5a0141d39e003767cf3b4f675b',
+                                                                                            'valid' => true,
+                                                                                            'tenant' => 'test',
+                                                                                            'message' => {
+                                                                                              'custom_params' => {
+                                                                                                'custom_one' => 'this is one',
+                                                                                                'custom_two' => 'this is two',
+                                                                                              },
+                                                                                            },
+                                                                                          })
     allow_any_instance_of(NotifyMeetingWatcherJob).to(receive(:bbb).and_return(bbb_api)) # stub actioncable processes
     allow_any_instance_of(BrokerHelper).to(receive(:broker_tenant_info).and_return({
                                                                                      'handler_params' => 'context_id',
@@ -17,6 +28,12 @@ describe RoomsController, type: :controller do
                                                                                      'bigbluebutton_secret' => 'supersecretsecret',
                                                                                      'enable_shared_rooms' => 'true',
                                                                                      'bigbluebutton_moderator_roles' => 'administrator,teacher',
+                                                                                     'ext_params' => {
+                                                                                       'join' =>
+                                                                                          { 'custom_one' => 'userdata-one' },
+                                                                                       'create' =>
+                                                                                          { 'custom_two' => 'meta_two' },
+                                                                                     },
                                                                                    }))
 
     @request.session['handler'] = {


### PR DESCRIPTION
LTI-388: Looks for the parameters in the entire launch params hierarchy, rather than just the custom_params nested hash.
LTI-389: Stops storing the params to be sent to BBB in the room's settings column, but rather stores them in an instance variable. 
LTI-390: This PR also fixes the issue in which the wrong data is sent to BBB when using shared rooms