### PR TITLE
Fix room settings being wiped when saved with 'Use Shared Code' enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this app is
+
+bbb-app-rooms is a Rails 6.1 LTI tool that provides BigBlueButton rooms to LMSs (Moodle, Canvas, etc.). It does **not** speak LTI directly — it sits behind [bbb-lti-broker](https://github.com/bigbluebutton/bbb-lti-broker), which handles the LTI handshake and hands off to this app via OmniAuth (`omniauth-bbbltibroker` strategy). Running it locally requires a broker and typically the [bbb-lti-run](https://github.com/blindsidenetworks/bbb-lti-run) docker-compose environment (see README.md for the full setup).
+
+## Commands
+
+```bash
+bundle install                  # Ruby deps (Ruby 3.1.4 in CI; PostgreSQL required)
+yarn install                    # JS deps (webpacker 6 + Tailwind)
+
+bundle exec rake db:setup       # create/migrate/seed (uses DATABASE_URL or config/database.yml)
+
+bundle exec rspec               # run the test suite (spec/ — CI runs this)
+bundle exec rspec spec/controllers/rooms_spec.rb        # single file
+bundle exec rspec spec/controllers/rooms_spec.rb:42     # single example
+
+bundle exec rubocop             # lint (CI enforces; config in .rubocop.yml)
+
+rails s -b 0.0.0.0 -p 3012      # dev server (README's dev flow pairs it with the broker on 3011)
+```
+
+Environment comes from a `.env` file (dotenv-rails); copy `dotenv` to `.env` as a template. Key vars: `BIGBLUEBUTTON_ENDPOINT`/`BIGBLUEBUTTON_SECRET`, `OMNIAUTH_BBBLTIBROKER_SITE`/`_ROOT`/`_KEY`/`_SECRET`, `URL_HOST`, `RELATIVE_URL_ROOT` (usually `apps`), `SECRET_KEY_BASE`.
+
+Tests live in `spec/` (RSpec + FactoryBot + webmock). The `test/` directory is leftover minitest scaffolding — CI does not run it; put new tests in `spec/`.
+
+## Architecture
+
+### Launch flow (the core path)
+
+1. LMS launches the tool through the broker; broker redirects here with a `launch_nonce`.
+2. `SessionsController#create` (OmniAuth callback at `/rooms/auth/bbbltibroker/callback`) stores the authenticated `uid` in the Rails session keyed by `launch_nonce`.
+3. `RoomsController#launch` (`POST /rooms/launch`) calls back to the broker REST API (`/api/v1/sessions/:launch_nonce`, OAuth2 client-credentials token) to pull the full LTI launch params, then finds-or-creates the `Room` and stores the user's launch params in the session keyed by the room's `handler`.
+4. Subsequent requests hit `set_room`, which loads the room by `:handler` and rebuilds `@user` (`BbbAppRooms::User`, a plain Ruby object in `lib/bbb_app_rooms/` — there is no users table; identity exists only in the session).
+
+### Key pieces
+
+- **`Room`** (the only ActiveRecord model): one row per LTI resource, identified by `handler` (a SHA1; `to_param` returns it, so all URL helpers use `/rooms/:handler`). Meeting/lock options (`record`, `guestPolicy`, `allModerators`, `lockSettings*`, etc.) live in the JSON `settings` column via `store_accessor`. A room may have a shared code pointing at another room; `set_chosen_room` in `RoomsController` swaps in the shared room, and most BBB operations act on `@chosen_room` rather than `@room`.
+- **`BbbHelper`** (`app/controllers/concerns/bbb_helper.rb`): all BigBlueButton API interaction — create/join meeting URLs, recordings (paginated via pagy), publish/protect/delete — through the `bigbluebutton-api-ruby` gem. Recordings and meeting info are cached in `Rails.cache` when `CACHE_ENABLED`.
+- **`Bbb::Credentials`** (`lib/bbb/credentials.rb`): resolves BBB endpoint/secret per tenant. Single-tenant installs use `BIGBLUEBUTTON_ENDPOINT`/`SECRET` env vars; multitenant installs fetch per-tenant credentials from the broker's tenants API and cache them.
+- **`BrokerHelper` / `OmniauthHelper`**: REST calls to the broker (tenant settings such as `enable_shared_rooms`, `handler_params`) and OmniAuth URL/token plumbing. Tenant settings gate features, so behavior can differ per tenant at runtime.
+- **ActionCable** (`MeetingInfoChannel` + `NotifyMeetingWatcherJob`): clients on the room page subscribe with the room handler; the job polls BBB and broadcasts meeting status so the page updates (join button, participant info) without refreshing. `Room#broadcast_room_start` also broadcasts on a `wait_channel:room_<id>` stream. Redis-backed in production.
+- **Errors**: `RoomsError::CustomError` (`lib/rooms_error/error.rb`) carries `{code, message, key}`; controllers rescue it and render the shared `error` view. Non-launch failures also flow through `set_error` + `ErrorsController`.
+- **Routing**: everything is under the `rooms` scope (plus `RELATIVE_URL_ROOT` prefix in deployment, e.g. `/apps/rooms/...`). Meeting and recording actions are member-style routes under `/:handler/`.
+- **Presentation upload**: ActiveStorage (`has_one_attached :presentation`), stored in GCS/S3-compatible storage in production (`config/storage.yml`), passed to BBB as the meeting's pre-upload document.
+
+### Things that aren't obvious
+
+- The app is designed to render inside an LMS iframe: `allow_iframe_requests` strips `X-Frame-Options`, and session cookies must survive third-party-cookie restrictions.
+- Sessions are DB-backed (`activerecord-session_store`), not cookie-backed.
+- `handler` vs `handler_legacy`: `Room#handler` returns `handler_legacy` when present, to keep pre-existing rooms resolvable after the handler scheme changed.
+- Deployment is Docker-based (Dockerfile + `scripts/start.sh`); GitHub Actions builds images on push/release, and `cloudbuild*.yaml` cover a GCP pipeline.

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -425,7 +425,7 @@ class RoomsController < ApplicationController
   end
 
   def room_params
-    params.require(:room).permit(
+    permitted = params.require(:room).permit(
       :name,
       :description,
       :welcome,
@@ -441,6 +441,11 @@ class RoomsController < ApplicationController
       :presentation,
       settings: Room.stored_attributes[:settings]
     )
+    # While 'Use Shared Code' is checked, the settings checkboxes are disabled in the form,
+    # so only their hidden '0' companion fields get submitted. Keep the room's stored
+    # settings instead of overwriting them all with zeros.
+    permitted.delete(:settings) if ActiveModel::Type::Boolean.new.cast(permitted[:use_shared_code])
+    permitted
   end
 
   def launch_params_to_new_room_params(handler, handler_legacy, launch_params)

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -206,6 +206,7 @@ class Room < ApplicationRecord
 
   def shared_code_presence
     errors.add(:shared_code, "The shared code can't be blank when 'Use Shared Code' is enabled") && return if shared_code.blank?
+    errors.add(:shared_code, "A room can't use its own code as a shared code") && return if shared_code == code
 
     return if Room.exists?(code: shared_code, tenant: tenant)
 

--- a/spec/controllers/rooms_spec.rb
+++ b/spec/controllers/rooms_spec.rb
@@ -150,6 +150,52 @@ describe RoomsController, type: :controller do
         },
       }
     end
+
+    context 'settings while using a shared code' do
+      let(:all_settings_enabled) { Room.stored_attributes[:settings].index_with { '1' }.transform_keys(&:to_s) }
+      let(:all_settings_zeroed) { Room.stored_attributes[:settings].index_with { '0' } }
+
+      before do
+        # Rooms leak across examples (DatabaseCleaner strategies are set but never run),
+        # so a unique handler is needed for find_by(handler:) to resolve this room.
+        @room.update!(handler: SecureRandom.hex(8), settings: all_settings_enabled)
+        @request.session[@room.handler] = @request.session['handler']
+      end
+
+      it 'keeps the stored settings when the form is submitted with use_shared_code enabled' do
+        owner = create(:room, handler: 'owner-handler', tenant: @room.tenant)
+
+        # The form disables the settings checkboxes while 'Use Shared Code' is checked,
+        # so the submission only carries the hidden '0' fields for every setting.
+        patch :update, params: {
+          handler: @room.handler,
+          room: {
+            name: @room.name,
+            use_shared_code: '1',
+            shared_code: owner.code,
+            settings: all_settings_zeroed,
+          },
+        }
+
+        @room.reload
+        expect(@room.use_shared_code).to(be(true))
+        expect(@room.shared_code).to(eq(owner.code))
+        expect(@room.settings).to(eq(all_settings_enabled))
+      end
+
+      it 'applies submitted settings when use_shared_code is disabled' do
+        patch :update, params: {
+          handler: @room.handler,
+          room: {
+            name: @room.name,
+            use_shared_code: '0',
+            settings: all_settings_zeroed,
+          },
+        }
+
+        expect(@room.reload.settings['record']).to(eq('0'))
+      end
+    end
   end
 
   describe '#meeting_end' do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Room, type: :model do
+  describe 'shared code validation' do
+    it 'rejects a room using its own code as its shared code' do
+      room = create(:room)
+      room.use_shared_code = true
+      room.shared_code = room.code
+
+      expect(room).not_to(be_valid)
+      expect(room.errors[:shared_code]).to(include("A room can't use its own code as a shared code"))
+    end
+
+    it "accepts another room's code from the same tenant" do
+      room = create(:room)
+      owner = create(:room, handler: 'owner-handler', tenant: room.tenant)
+      room.use_shared_code = true
+      room.shared_code = owner.code
+
+      expect(room).to(be_valid)
+    end
+
+    it 'rejects a code that does not belong to any room in the tenant' do
+      room = create(:room)
+      room.use_shared_code = true
+      room.shared_code = 'nonexistent'
+
+      expect(room).not_to(be_valid)
+      expect(room.errors[:shared_code]).to(include('A room with this code could not be found'))
+    end
+  end
+end


### PR DESCRIPTION
When a room's edit form is submitted while 'Use Shared Code' is checked, JavaScript has disabled all the settings checkboxes (lock settings, room settings, and recording settings). Disabled inputs are not submitted, so the only values that reach the server are the hidden '0' companion fields that Rails renders next to each checkbox. The update then overwrote the room's entire settings hash with zeros - turning off record, allowStartStopRecording, guest policy, and every lock setting - silently, on every save.

For a room whose code drives a shared meeting, this removed the record button from BigBlueButton for all connected classes, and the setting could not be restored through the UI: the checkboxes stay disabled while sharing is on, and any save with the box checked re-wiped the settings.

Reported by a teacher sharing one room across 23 summer school classes: recording worked on day one, the record button disappeared on day two, and recording permission could not be restored.

Changes:
- RoomsController#room_params now drops the settings hash when the form is submitted with use_shared_code enabled, preserving the room's stored settings. They are unused while sharing is active and remain intact if sharing is later disabled or revoked.
- Room#shared_code_presence now rejects a room using its own code as its shared code. Self-sharing exposed the meeting-owning room itself to the settings wipe while appearing to work normally.
- Regression specs for both, plus a new model spec for the shared code validation. The new controller specs use a unique room handler because rooms leak between examples (DatabaseCleaner strategies are configured but never run) and find_by(handler:) would otherwise resolve to a stale room from an earlier example.
- Add CLAUDE.md with repo guidance for Claude Code (build/test commands, architecture overview).